### PR TITLE
파일 복사문제 수정

### DIFF
--- a/rocky.sh
+++ b/rocky.sh
@@ -13,8 +13,8 @@ fi
 
 # 기존 repo 파일 백업
 for f in /etc/yum.repos.d/*.repo; do
-    [ -e "$f" ] && cp "$f" ".${f}.bak.$(date +%Y%m%d)"
-    echo "기존 repo 파일을 백업했습니다: ${f}.bak.$(date +%Y%m%d)"
+    [ -e "$f" ] && cp "$f" ".${f##*/}.bak.$(date +%Y%m%d)"
+    echo "기존 repo 파일을 백업했습니다: ${f##*/}.bak.$(date +%Y%m%d)"
 done
 
 rm -f /etc/yum.repos.d/*.repo


### PR DESCRIPTION
rocky linux용 미러변경 스크립트 파일 복사문제 수정

**변경 전**:
cp: cannot create regular file './etc/yum.repos.d/rocky-addons.repo.bak.20250810': No such file or directory

**변경 후**:
기존 repo 파일을 백업했습니다: rocky-addons.repo.bak.20250810
기존 repo 파일을 백업했습니다: rocky-devel.repo.bak.20250810
기존 repo 파일을 백업했습니다: rocky-extras.repo.bak.20250810
기존 repo 파일을 백업했습니다: rocky.repo.bak.20250810